### PR TITLE
docs: improve code snippet in install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ A Docusaurus plugin for [Plausible](https://plausible.io/) analytics. Inspired b
     ...
     plugins: [
       [
-        path.resolve(__dirname, '../docusaurus-plugin-plausible'),
+        'docusaurus-plugin-plausible',
         {
-          domain,
+          domain: 'your-website.com',
         },
       ]
     ],


### PR DESCRIPTION
Seems like the `path` isn't really required (and can confuse users, who would need to add an import).
Also add a placeholder for the domain name